### PR TITLE
Allow custom app name on statsd

### DIFF
--- a/lib/datadoge/metrics.rb
+++ b/lib/datadoge/metrics.rb
@@ -3,8 +3,16 @@ require 'datadog/statsd'
 module Datadoge
   # A wrapper for a Datadog::Statsd instance with proper prefixes applied.
   class Metrics
+    def self.app_name=(val)
+      @app_name = val
+    end
+
+    def self.app_name
+      @app_name || ENV['APP_NAME']
+    end
+
     def self.prefix
-      "app.#{ENV['APP_NAME']}"
+      "app.#{app_name}"
     end
 
     def self.statsd


### PR DESCRIPTION
This allows apps to specify the app_name used by Datadoge::Metrics. Also cleans up the railtie to use the Metrics module. 